### PR TITLE
Fix: pin dependencies for reproducible installs (#14)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-groq
-google-generativeai
-python-dotenv
-twilio
-supabase
+# Pinned dependencies for reproducible builds (Issue #14)
+groq==0.9.0
+google-generativeai==0.8.3
+python-dotenv==1.0.1
+twilio==9.3.3
+supabase==2.10.0


### PR DESCRIPTION
Fixes #14

- Pinned all dependencies in requirements.txt
- Ensures consistent and reproducible environments
- Prevents breakage due to upstream updates

Tested locally: installed successfully with no errors
